### PR TITLE
Reposition yangjeep.io as engineering notes site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,50 @@
-# Oh Hey! 
+# Yangjeep Engineering Notes
 
-Check my site out at [yangjeep.io][yangjeepio-def]
+Source for [**yangjeep.io**](https://yangjeep.io) — my technical blog / engineering notes site.
 
-[yangjeepio-def]: https://yangjeep.io/
+Technical writing on engineering leadership, SaaS platforms, backend and data systems,
+AI-assisted engineering workflows, homelab infrastructure, and product building.
+
+## Related sites
+
+- **Main personal landing page** — [yangjeep.com](https://yangjeep.com)
+- **Formal resume / profile** — [jiajianyang.com](https://jiajianyang.com)
+- **Photography portfolio** — [photo.yangjeep.io](https://photo.yangjeep.io)
+
+## Stack
+
+A [Chirpy](https://github.com/cotes2020/jekyll-theme-chirpy) Jekyll site. Content lives in
+`_posts/` (articles), `_tabs/` (nav pages), `_data/` (site data), and `_layouts/home.html`
+(the homepage). See [`CLAUDE.md`](CLAUDE.md) for conventions.
+
+## Local development
+
+```bash
+bundle install                 # install Ruby dependencies
+bundle exec jekyll serve       # serve locally at http://localhost:4000
+```
+
+The `assets/lib/` submodule must be initialized for the theme to render:
+
+```bash
+git submodule update --init
+```
+
+## Build
+
+```bash
+JEKYLL_ENV=production bundle exec jekyll build -d "_site"
+```
+
+Link-check the built site (same check the CI runs):
+
+```bash
+bundle exec htmlproofer _site \
+  --disable-external=true \
+  --ignore-urls "/^http:\/\/127.0.0.1/,/^http:\/\/0.0.0.0/,/^http:\/\/localhost/"
+```
+
+## Deployment
+
+Hosted on **GitHub Pages**. Deployment is automatic via GitHub Actions
+(`.github/workflows/pages-deploy.yml`) on push to `main`.

--- a/_config.yml
+++ b/_config.yml
@@ -19,14 +19,13 @@ timezone:
 # jekyll-seo-tag settings › https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/usage.md
 # ↓ --------------------------
 
-title: Jiajian Yang                      # the main title
+title: Yangjeep Engineering Notes                      # the main title
 
-tagline: Engineering leader, infrastructure builder, and product-minded technologist.   # it will display as the sub-title
+tagline: Technical notes on infrastructure, systems, AI workflows, and engineering leadership.   # it will display as the sub-title
 
 description: >-                        # used by seo meta and the atom feed
-  Engineering leader building platform and backend systems, AI-native infrastructure, and products.
-  Based in Ottawa, Canada. Writing about engineering leadership, distributed systems, AI workflows,
-  homelabs, and product building.
+  Technical writing by Jiajian Yang on engineering leadership, SaaS platforms, backend and data
+  systems, AI-assisted engineering workflows, homelab infrastructure, and product building.
 
 # fill in the protocol & hostname for your site, e.g., 'https://username.github.io'
 url: 'https://yangjeep.io'
@@ -41,13 +40,12 @@ social:
   # Change to your full name.
   # It will be displayed as the default author of the posts and the copyright owner in the Footer
   name: Jiajian Yang
-  email: jj@yangjeep.io             # change to your email address
+  email: jj@yangjeep.com             # change to your email address
   links:
     # The first element serves as the copyright owner's link
-    - https://twitter.com/yangjeep      # change to your twitter homepage
+    - https://yangjeep.com              # main personal landing page
+    - https://jiajianyang.com           # formal resume / profile
     - https://github.com/yangjeep       # change to your github homepage
-    # Uncomment below to add more social links
-    # - https://www.facebook.com/username
     - https://www.linkedin.com/in/yangjeep
     - https://photo.yangjeep.io
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -179,22 +179,22 @@ layout: default
 
 <!-- ── Hero ─────────────────────────────────────────────── -->
 <section class="jj-hero">
-  <h1 class="jj-hero-name">Jiajian Yang</h1>
-  <p class="jj-hero-subtitle">Engineering leader, infrastructure builder, and product-minded technologist.</p>
+  <h1 class="jj-hero-name">Yangjeep Engineering Notes</h1>
+  <p class="jj-hero-subtitle">Technical notes on infrastructure, systems, AI-assisted engineering workflows, and engineering leadership.</p>
   <p class="jj-hero-bio">
-    I build platform and backend systems, lead engineering teams, and explore AI-native infrastructure.
-    I'm based in Ottawa, Canada, and currently building
-    <a href="https://leaselab.io" target="_blank" rel="noopener noreferrer">LeaseLab</a>,
-    an event-driven property management platform.
+    This is my technical writing space — infrastructure, systems, AI-assisted engineering
+    workflows, SaaS operations, homelab work, and engineering leadership. For a concise
+    personal profile, visit <a href="https://yangjeep.com" target="_blank" rel="noopener noreferrer">yangjeep.com</a>.
+    For my formal resume, visit <a href="https://jiajianyang.com" target="_blank" rel="noopener noreferrer">jiajianyang.com</a>.
   </p>
   <div class="jj-hero-links">
-    <a class="jj-btn primary" href="https://leaselab.io"
+    <a class="jj-btn primary" href="/archives">Read the notes</a>
+    <a class="jj-btn" href="https://yangjeep.com"
        target="_blank" rel="noopener noreferrer"
-       data-outbound="leaselab">LeaseLab</a>
-    <a class="jj-btn" href="/archives">Blog</a>
-    <a class="jj-btn" href="https://photo.yangjeep.io"
+       data-outbound="main-site">Main site</a>
+    <a class="jj-btn" href="https://jiajianyang.com"
        target="_blank" rel="noopener noreferrer"
-       data-outbound="photography">Photography Portfolio</a>
+       data-outbound="formal-profile">Formal profile</a>
     <a class="jj-btn" href="https://github.com/yangjeep"
        target="_blank" rel="noopener noreferrer"
        data-outbound="github">GitHub</a>
@@ -204,32 +204,34 @@ layout: default
   </div>
 </section>
 
-<!-- ── Featured Projects ─────────────────────────────────── -->
-<h2 class="jj-section-title">Featured Projects</h2>
+<!-- ── Where to go ───────────────────────────────────────── -->
+<h2 class="jj-section-title">Where to go</h2>
 <div class="jj-cards">
-  <a class="jj-card" href="https://leaselab.io"
+  <a class="jj-card" href="https://yangjeep.com"
      target="_blank" rel="noopener noreferrer"
-     data-outbound="leaselab">
-    <p class="jj-card-title">LeaseLab</p>
+     data-outbound="main-site">
+    <p class="jj-card-title">Main site → yangjeep.com</p>
     <p class="jj-card-desc">
-      Event-driven, workflow-centric property management platform.
-      Modern async-first stack built for real operational complexity.
+      My personal landing page — the concise starting point for who I am
+      and what I'm working on.
     </p>
   </a>
-  <a class="jj-card" href="/archives">
-    <p class="jj-card-title">Technical Blog</p>
+  <a class="jj-card" href="https://jiajianyang.com"
+     target="_blank" rel="noopener noreferrer"
+     data-outbound="formal-profile">
+    <p class="jj-card-title">Formal profile → jiajianyang.com</p>
     <p class="jj-card-desc">
-      Engineering leadership, infrastructure, AI-native workflows,
-      homelabs, and product building — captured as I go.
+      My resume and professional profile in full — background, roles,
+      and experience.
     </p>
   </a>
   <a class="jj-card" href="https://photo.yangjeep.io"
      target="_blank" rel="noopener noreferrer"
      data-outbound="photography">
-    <p class="jj-card-title">Photography Portfolio</p>
+    <p class="jj-card-title">Photography → photo.yangjeep.io</p>
     <p class="jj-card-desc">
       Travel, architecture, museums/interiors, and cityscape work.
-      Hosted on Adobe Portfolio at photo.yangjeep.io.
+      Hosted on Adobe Portfolio.
     </p>
   </a>
 </div>

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -4,29 +4,18 @@ icon: fas fa-info-circle
 order: 5
 ---
 
-Hi, I'm **Jiajian Yang** — you can call me JJ.
+Hi, I'm **Jiajian Yang** — you can call me JJ. I'm an engineering leader based in **Ottawa, Canada**.
 
-I'm an engineering leader based in **Ottawa, Canada**. My work sits at the intersection of platform engineering, backend systems, data infrastructure, and AI-native product development. I care about building teams that ship reliably and systems that hold up under real load.
+### What this site is
 
-Currently I'm building [**LeaseLab**](https://leaselab.io) — an event-driven, workflow-centric property management platform designed around operational complexity rather than around forms.
+**Yangjeep Engineering Notes** is my technical writing space. I use it to capture notes on infrastructure, SaaS systems, backend and data platforms, AI-assisted engineering workflows, homelab work, and engineering leadership — the trade-offs and experiments as I go.
 
-### What I work on
+Browse by [category](/categories) or [tag](/tags), or see everything in the [archives](/archives).
 
-- **Engineering leadership** — team design, hiring, technical direction, and delivery culture
-- **Platform & backend systems** — distributed architecture, async-first workflows, API design
-- **Data & AI infrastructure** — pipelines, LLM-backed workflows, observability
-- **Homelab** — self-hosted infrastructure, networking, and experimentation
+### Where to go
 
-### Writing
-
-This blog is where I capture notes on the above — engineering trade-offs, infrastructure experiments, AI tooling, and the occasional product post. Browse by [category](/categories) or [tag](/tags), or see everything in the [archives](/archives).
-
-### Photography
-
-When I'm not at a keyboard, I'm often behind a camera. I shoot travel, architecture, museum interiors, and cityscapes. You can see the portfolio at [photo.yangjeep.io](https://photo.yangjeep.io).
-
-### Connect
-
-- [GitHub](https://github.com/yangjeep)
-- [LinkedIn](https://www.linkedin.com/in/yangjeep)
-- [Photography Portfolio](https://photo.yangjeep.io)
+- **Main landing page** — [yangjeep.com](https://yangjeep.com)
+- **Formal profile / resume** — [jiajianyang.com](https://jiajianyang.com)
+- **GitHub** — [github.com/yangjeep](https://github.com/yangjeep)
+- **LinkedIn** — [linkedin.com/in/yangjeep](https://www.linkedin.com/in/yangjeep)
+- **Photography** — [photo.yangjeep.io](https://photo.yangjeep.io)


### PR DESCRIPTION
## Summary

- Repositions **yangjeep.io** as the technical blog / engineering notes site
- Keeps **yangjeep.com** as the main personal landing page
- Keeps **jiajianyang.com** as the formal resume/profile site
- Updates site metadata, homepage/about copy, and README

### Changes

- **`_config.yml`** — new `title` (*Yangjeep Engineering Notes*), `tagline`, and `description`; social email updated `jj@yangjeep.io` → `jj@yangjeep.com`; social links now lead with `yangjeep.com` (copyright owner link) and add `jiajianyang.com`, keeping GitHub, LinkedIn, and photo.yangjeep.io. Canonical `url` remains `https://yangjeep.io` — no canonical conflict with yangjeep.com.
- **`_layouts/home.html`** — homepage hero reframed as the engineering-notes site; adds a clear "Where to go" section pointing to the main site, formal profile, and photography. No longer presents itself as the primary personal landing page.
- **`_tabs/about.md`** — rewritten as a blog/about page (who I am + what this site is + where to go); resume-style content moved off to jiajianyang.com.
- **`README.md`** — explains this repo powers yangjeep.io (the notes site), links the related sites, and documents local dev, build, and GitHub Pages deployment.

### Not changed (by design)

- Canonical URL stays `https://yangjeep.io`
- No hosting/deployment changes — still GitHub Pages via `.github/workflows/pages-deploy.yml`
- No posts removed

## Testing

- `bundle exec jekyll build` + htmlproofer — **not run**. The dev environment has no Ruby/Bundler or container runtime, so I could not build locally. Note the existing workflow (`pages-deploy.yml`) triggers only on `push` to `main` (and `workflow_dispatch`), so **it does not run on this PR** — the full build/link-check will execute when this is merged to `main`. A reviewer can validate ahead of merge by building locally:
  ```bash
  bundle exec jekyll build
  bundle exec htmlproofer _site --disable-external=true \
    --ignore-urls "/^http:\/\/127.0.0.1/,/^http:\/\/0.0.0.0/,/^http:\/\/localhost/"
  ```
- Static verification performed here: `_config.yml` and `_data/*.yml` validated as well-formed YAML; internal links used on the homepage/about (`/archives`, `/categories`, `/tags`) confirmed to have matching `_tabs/` pages (htmlproofer runs internal-only in CI); external links reviewed (`yangjeep.com`, `jiajianyang.com`, `github.com/yangjeep`, `linkedin.com/in/yangjeep`, `photo.yangjeep.io`).

Do not merge yet — pending local build validation + review.
