### PR TITLE
Refocus Engineering Notes on systems, platform, and leadership depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Source for [**yangjeep.io**](https://yangjeep.io) — my technical blog / engineering notes site.
 
-Technical writing on engineering leadership, SaaS platforms, backend and data systems,
-AI-assisted engineering workflows, homelab infrastructure, and product building.
+Technical writing on systems and platform architecture, infrastructure and reliability,
+cloud economics, developer tooling, data infrastructure, AI-assisted engineering workflows,
+homelab systems, and engineering leadership.
 
 ## Related sites
 
-- **Main personal landing page** — [yangjeep.com](https://yangjeep.com)
-- **Formal resume / profile** — [jiajianyang.com](https://jiajianyang.com)
+- **Canonical personal/professional hub** — [yangjeep.com](https://yangjeep.com)
 - **Photography portfolio** — [photo.yangjeep.io](https://photo.yangjeep.io)
 
 ## Stack

--- a/_config.yml
+++ b/_config.yml
@@ -21,13 +21,12 @@ timezone:
 
 title: Yangjeep Engineering Notes                      # the main title
 
-tagline: Field notes from an unconventional technical leader.   # it will display as the sub-title
+tagline: Field notes on systems, platforms, infrastructure, and engineering leadership.   # it will display as the sub-title
 
 description: >-                        # used by seo meta and the atom feed
-  Technical field notes by Jiajian Yang — infrastructure, distributed systems, AI and agentic
-  workflows, customer engineering, developer platforms, homelab, and engineering organizations.
-  The technical notebook of an unconventional technical leader; for a formal profile see
-  jiajianyang.com.
+  Technical field notes by Jiajian Yang on systems and platform architecture, infrastructure
+  and reliability, cloud economics, developer tooling, data infrastructure, AI-assisted
+  engineering workflows, homelab systems, and engineering leadership.
 
 # fill in the protocol & hostname for your site, e.g., 'https://username.github.io'
 url: 'https://yangjeep.io'
@@ -45,9 +44,8 @@ social:
   email: jj@yangjeep.com             # change to your email address
   links:
     # The first element serves as the copyright owner's link
-    - https://yangjeep.com              # main personal landing page
-    - https://jiajianyang.com           # formal resume / profile
-    - https://github.com/yangjeep       # change to your github homepage
+    - https://yangjeep.com              # canonical personal/professional hub
+    - https://github.com/yangjeep       # GitHub profile
     - https://www.linkedin.com/in/yangjeep
     - https://photo.yangjeep.io
 
@@ -61,7 +59,7 @@ google_analytics:
   # Google Analytics pageviews report settings
   pv:
     proxy_endpoint:   # fill in the Google Analytics superProxy endpoint of Google App Engine
-    cache_path:       # the local PV cache data, friendly to visitors from GFW region
+    cache_path:       # local PV cache data, friendly to visitors from GFW region
 
 # Prefer color scheme setting.
 #
@@ -90,22 +88,19 @@ avatar: '/assets/avatar.png'
 toc: true
 
 comments:
-  active:         # The global switch for posts comments, e.g., 'disqus'.  Keep it empty means disable
+  active:         # The global switch for posts comments, e.g. 'disqus'.  Keep it empty means disable
   # The active options are as follows:
   disqus:
     shortname:    # fill with the Disqus shortname. › https://help.disqus.com/en/articles/1717111-what-s-a-shortname
-  # utterances settings › https://utteranc.es/
   utterances:
     repo:         # <gh-username>/<repo>
     issue_term:   # < url | pathname | title | ...>
-  # Giscus options › https://giscus.app
   giscus:
     repo:              # <gh-username>/<repo>
     repo_id:
     category:
     category_id:
     mapping:           # optional, default to 'pathname'
-    input_position:    # optional, default to 'bottom'
     lang:              # optional, default to the value of `site.lang`
     reactions_enabled: # optional, default to the value of `1`
 
@@ -113,8 +108,7 @@ comments:
 assets:
   self_host:
     enabled:      # boolean, keep empty means false
-    # specify the Jekyll environment, empty means both
-    # only works if `assets.self_host.enabled` is 'true'
+    # specify the environment, empty means both
     env:          # [development|production]
 
 pwa:
@@ -128,7 +122,7 @@ kramdown:
   syntax_highlighter: rouge
   syntax_highlighter_opts:   # Rouge Options › https://github.com/jneen/rouge#full-options
     css_class: highlight
-    # default_lang: console
+    default_lang: console
     span:
       line_numbers: false
     block:
@@ -147,7 +141,7 @@ defaults:
     values:
       layout: post
       comments: true    # Enable comments in posts.
-      toc: true         # Display TOC column in posts.
+      toc: true         # Display ToC column in posts.
       # DO NOT modify the following parameter unless you are confident enough
       # to update the code of all other post links in this project.
       permalink: /posts/:title/
@@ -163,10 +157,6 @@ defaults:
       permalink: /:title/
   - scope:
       path: assets/img/favicons
-    values:
-      swcache: true
-  - scope:
-      path: assets/js/dist
     values:
       swcache: true
 

--- a/_config.yml
+++ b/_config.yml
@@ -45,7 +45,7 @@ social:
   links:
     # The first element serves as the copyright owner's link
     - https://yangjeep.com              # canonical personal/professional hub
-    - https://github.com/yangjeep       # GitHub profile
+    - https://github.com/yangjeep       # change to your github homepage
     - https://www.linkedin.com/in/yangjeep
     - https://photo.yangjeep.io
 
@@ -58,8 +58,8 @@ google_analytics:
   id: G-7Z26FPD1KF    # GA4 Measurement ID
   # Google Analytics pageviews report settings
   pv:
-    proxy_endpoint:   # fill in to your Google Analytics superProxy endpoint of Google App Engine
-    cache_path:       # local PV cache data, friendly to visitors from GFW region
+    proxy_endpoint:   # fill in the Google Analytics superProxy endpoint of Google App Engine
+    cache_path:       # the local PV cache data, friendly to visitors from GFW region
 
 # Prefer color scheme setting.
 #
@@ -88,7 +88,7 @@ avatar: '/assets/avatar.png'
 toc: true
 
 comments:
-  active:         # The global switch for posts comments, e.g. 'disqus'.  Keep it empty means disable
+  active:         # The global switch for posts comments, e.g., 'disqus'.  Keep it empty means disable
   # The active options are as follows:
   disqus:
     shortname:    # fill with the Disqus shortname. › https://help.disqus.com/en/articles/1717111-what-s-a-shortname
@@ -103,6 +103,7 @@ comments:
     category:
     category_id:
     mapping:           # optional, default to 'pathname'
+    input_position:    # optional, default to 'bottom'
     lang:              # optional, default to the value of `site.lang`
     reactions_enabled: # optional, default to the value of `1`
 
@@ -110,7 +111,8 @@ comments:
 assets:
   self_host:
     enabled:      # boolean, keep empty means false
-    # specify the environment, empty means both
+    # specify the Jekyll environment, empty means both
+    # only works if `assets.self_host.enabled` is 'true'
     env:          # [development|production]
 
 pwa:
@@ -143,7 +145,7 @@ defaults:
     values:
       layout: post
       comments: true    # Enable comments in posts.
-      toc: true         # Display ToC column in posts.
+      toc: true         # Display TOC column in posts.
       # DO NOT modify the following parameter unless you are confident enough
       # to update the code of all other post links in this project.
       permalink: /posts/:title/
@@ -159,6 +161,10 @@ defaults:
       permalink: /:title/
   - scope:
       path: assets/img/favicons
+    values:
+      swcache: true
+  - scope:
+      path: assets/js/dist
     values:
       swcache: true
 

--- a/_config.yml
+++ b/_config.yml
@@ -58,7 +58,7 @@ google_analytics:
   id: G-7Z26FPD1KF    # GA4 Measurement ID
   # Google Analytics pageviews report settings
   pv:
-    proxy_endpoint:   # fill in the Google Analytics superProxy endpoint of Google App Engine
+    proxy_endpoint:   # fill in to your Google Analytics superProxy endpoint of Google App Engine
     cache_path:       # local PV cache data, friendly to visitors from GFW region
 
 # Prefer color scheme setting.
@@ -92,9 +92,11 @@ comments:
   # The active options are as follows:
   disqus:
     shortname:    # fill with the Disqus shortname. › https://help.disqus.com/en/articles/1717111-what-s-a-shortname
+  # utterances settings › https://utteranc.es/
   utterances:
     repo:         # <gh-username>/<repo>
     issue_term:   # < url | pathname | title | ...>
+  # Giscus options › https://giscus.app
   giscus:
     repo:              # <gh-username>/<repo>
     repo_id:
@@ -122,7 +124,7 @@ kramdown:
   syntax_highlighter: rouge
   syntax_highlighter_opts:   # Rouge Options › https://github.com/jneen/rouge#full-options
     css_class: highlight
-    default_lang: console
+    # default_lang: console
     span:
       line_numbers: false
     block:

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -241,13 +241,13 @@ layout: default
 <section class="jj-hero">
   <h1 class="jj-hero-name">Yangjeep Engineering Notes</h1>
   <p class="jj-hero-subtitle">
-    Linux and carrier-grade infrastructure roots — now stretched across customers, AI,
-    and the business problems that don't respect org charts.
+    Linux and carrier-grade systems roots, now spanning platform infrastructure,
+    reliability, data systems, and engineering organizations.
   </p>
 
-  <!-- ── Signature motif: four domains in a loop, plus one direct
-       systems↔business link — the unconventional jump ────────── -->
-  <div class="jj-motif" role="img" aria-label="Diagram: systems, platforms, business, and customers connected in a loop, with one direct line from systems to business — an interconnected graph, not a career ladder">
+  <!-- ── Signature motif: technical systems and organizational scope
+       connected as one operating graph rather than separate careers ───── -->
+  <div class="jj-motif" role="img" aria-label="Diagram: systems, platforms, business, and engineering organizations connected as one operating graph">
     <svg viewBox="0 0 460 160" xmlns="http://www.w3.org/2000/svg">
       <line x1="70" y1="110" x2="185" y2="35" />
       <line x1="185" y1="35" x2="405" y2="70" />
@@ -261,10 +261,10 @@ layout: default
       <text x="70" y="132" text-anchor="middle">SYSTEMS</text>
       <text x="185" y="20" text-anchor="middle">PLATFORMS</text>
       <text x="405" y="52" text-anchor="middle">BUSINESS</text>
-      <text x="300" y="150" text-anchor="middle">CUSTOMERS</text>
+      <text x="300" y="150" text-anchor="middle">ORGANIZATION</text>
     </svg>
   </div>
-  <p class="jj-motif-caption jj-section-note">— same graph, not a ladder</p>
+  <p class="jj-motif-caption jj-section-note">— architecture, operations, economics, and ownership</p>
 
   <div class="jj-hero-links">
     <a class="jj-btn primary" href="/archives">Read the notes</a>
@@ -307,8 +307,8 @@ layout: default
   <li>
     <span class="jj-now-marker">▸</span>
     <span class="jj-now-body">
-      <strong>AI-assisted engineering systems</strong> — where agentic AI actually earns a place
-      in a support/engineering org, and where it doesn't yet.
+      <strong>Platform engineering &amp; economics</strong> — reliability, observability, cloud cost,
+      release infrastructure, and the architecture trade-offs behind operating systems well.
     </span>
   </li>
 </ul>
@@ -338,17 +338,8 @@ layout: default
      data-outbound="main-site">
     <p class="jj-card-title">Main site → yangjeep.com</p>
     <p class="jj-card-desc">
-      My personal landing page — the concise starting point for who I am
-      and what I'm working on.
-    </p>
-  </a>
-  <a class="jj-card" href="https://jiajianyang.com"
-     target="_blank" rel="noopener noreferrer"
-     data-outbound="formal-profile">
-    <p class="jj-card-title">Formal profile → jiajianyang.com</p>
-    <p class="jj-card-desc">
-      My résumé and professional profile in full — background, roles,
-      and experience.
+      The canonical starting point for my professional background, selected work,
+      projects, and contact details.
     </p>
   </a>
   <a class="jj-card" href="https://photo.yangjeep.io"

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -4,30 +4,35 @@ icon: fas fa-info-circle
 order: 5
 ---
 
-Hi, I'm **Jiajian Yang** — you can call me JJ. I've built an unconventional career by following hard problems across organizational boundaries.
+Hi, I'm **Jiajian Yang** — you can call me JJ.
 
-I started close to the metal: Linux, networking, and carrier-grade infrastructure. Over time the problems got wider — platforms, customers, APIs, data, security, AI, product, and eventually parts of the business itself. The common thread is that I tend to get pulled into technically difficult, commercially important problems that don't have an obvious owner.
+I'm an engineering leader with deep systems roots. I started close to the metal with Linux, networking, and carrier-grade infrastructure. Over time, the problems widened into platform engineering, reliability, cloud and data systems, developer infrastructure, security, and eventually the organizations responsible for operating them.
 
-Currently I'm Senior Director of Engineering at Athos Commerce, where I lead Customer Engineering, Support Engineering, Solutions Engineering, analytics and data platforms, cybersecurity, and AI enablement — plus General Manager duties for the Canadian entity. Before that, a decade at Cisco Systems as an engineer and then Engineering Manager on IOS-XR forwarding infrastructure, across 15+ carrier-grade hardware platforms. Earlier still, a Linux kernel quality engineering internship at Red Hat.
+Today I'm Senior Director of Engineering at Athos Commerce. My broader scope spans a globally distributed engineering organization, platform and data modernization, customer-facing engineering, cybersecurity, internal tooling, and AI enablement.
+
+Before Athos, I spent a decade at Cisco as an engineer and Engineering Manager working on IOS-XR forwarding infrastructure across 15+ carrier-grade hardware platforms. Earlier, I worked on Linux kernel quality engineering at Red Hat.
+
+The common thread has stayed fairly consistent: I like difficult systems problems, especially when architecture, operations, economics, and organizational ownership interact.
 
 ### What Engineering Notes is
 
-This is where I keep the technical side visible. I write down:
+This is where I keep the technical side visible. I write about:
 
-- things I'm building
-- systems I'm operating
-- infrastructure choices, and the ones I'd make differently
-- things that broke, and what that taught me
-- AI and agentic workflows that are actually useful
-- engineering and organizational patterns I keep running into
-- occasional experiments that may or may not have been sensible
+- systems I'm building and operating
+- platform and infrastructure architecture
+- reliability, observability, and things that broke
+- cloud economics and infrastructure trade-offs
+- developer tooling, CI/CD, and automation
+- data infrastructure
+- AI-assisted engineering workflows that survive contact with real work
+- engineering and organizational patterns
+- homelab experiments that I can break safely
 
 Browse by [category](/categories) or [tag](/tags), or see everything in the [archives](/archives).
 
 ### Where to go
 
-- **Main landing page** — [yangjeep.com](https://yangjeep.com)
-- **Formal profile / resume** — [jiajianyang.com](https://jiajianyang.com)
+- **Main site** — [yangjeep.com](https://yangjeep.com)
 - **GitHub** — [github.com/yangjeep](https://github.com/yangjeep)
 - **LinkedIn** — [linkedin.com/in/yangjeep](https://www.linkedin.com/in/yangjeep)
 - **Photography** — [photo.yangjeep.io](https://photo.yangjeep.io)


### PR DESCRIPTION
## Summary
- Reframe yangjeep.io as the technical-depth layer for the same Platform + VP Engineering identity
- Update homepage, About, SEO metadata, and repository README
- Remove duplicate jiajianyang.com formal-profile routing
- Reduce AI/customer-heavy framing in favor of systems, platform, reliability, economics, and engineering leadership

No existing technical history is expanded beyond current evidence.